### PR TITLE
Add GitSummary tool

### DIFF
--- a/docs/core/tools-api.md
+++ b/docs/core/tools-api.md
@@ -45,6 +45,7 @@ The core comes with a suite of pre-defined tools, typically found in `packages/c
   - `WebSearchTool` (`web-search.ts`): Performs a web search.
 - **Memory Tools:**
   - `MemoryTool` (`memoryTool.ts`): Interacts with the AI's memory.
+  - `GitSummaryTool` (`git-summary.ts`): Summarizes recent git commits.
 
 Each of these tools extends `BaseTool` and implements the required methods for its specific functionality.
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -23,6 +23,7 @@ import { WebFetchTool } from '../tools/web-fetch.js';
 import { ReadManyFilesTool } from '../tools/read-many-files.js';
 import { MemoryTool, setGeminiMdFilename } from '../tools/memoryTool.js';
 import { WebSearchTool } from '../tools/web-search.js';
+import { GitSummaryTool } from '../tools/git-summary.js';
 import { GeminiClient } from '../core/client.js';
 import { GEMINI_CONFIG_DIR as GEMINI_DIR } from '../tools/memoryTool.js';
 import { FileDiscoveryService } from '../services/fileDiscoveryService.js';
@@ -487,6 +488,7 @@ export function createToolRegistry(config: Config): Promise<ToolRegistry> {
   registerCoreTool(ShellTool, config);
   registerCoreTool(MemoryTool);
   registerCoreTool(WebSearchTool, config);
+  registerCoreTool(GitSummaryTool, targetDir);
   return (async () => {
     await registry.discoverTools();
     return registry;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -55,6 +55,7 @@ export * from './tools/web-search.js';
 export * from './tools/read-many-files.js';
 export * from './tools/mcp-client.js';
 export * from './tools/mcp-tool.js';
+export * from './tools/git-summary.js';
 
 // Export telemetry functions
 export * from './telemetry/index.js';

--- a/packages/core/src/tools/git-summary.test.ts
+++ b/packages/core/src/tools/git-summary.test.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GitSummaryTool } from './git-summary.js';
+import { simpleGit } from 'simple-git';
+
+vi.mock('simple-git');
+
+const mockedSimpleGit = vi.mocked(simpleGit);
+
+describe('GitSummaryTool', () => {
+  beforeEach(() => {
+    mockedSimpleGit.mockReturnValue({
+      log: vi.fn().mockResolvedValue({
+        all: [
+          { hash: 'abcdef1', message: 'test commit 1' },
+          { hash: 'abcdef2', message: 'test commit 2' },
+        ],
+      }),
+    } as any);
+  });
+
+  it('getDescription includes count', () => {
+    const tool = new GitSummaryTool('.');
+    expect(tool.getDescription({ count: 3 })).toBe('summary of last 3 commit(s)');
+  });
+
+  it('execute returns commit summary', async () => {
+    const tool = new GitSummaryTool('.');
+    const result = await tool.execute({ count: 2 }, new AbortController().signal);
+    expect(result.llmContent).toContain('abcdef1');
+    expect(result.llmContent).toContain('test commit 1');
+    expect(result.returnDisplay).toBe('2 commit(s)');
+  });
+});
+

--- a/packages/core/src/tools/git-summary.test.ts
+++ b/packages/core/src/tools/git-summary.test.ts
@@ -26,15 +26,19 @@ describe('GitSummaryTool', () => {
 
   it('getDescription includes count', () => {
     const tool = new GitSummaryTool('.');
-    expect(tool.getDescription({ count: 3 })).toBe('summary of last 3 commit(s)');
+    expect(tool.getDescription({ count: 3 })).toBe(
+      'summary of last 3 commit(s)',
+    );
   });
 
   it('execute returns commit summary', async () => {
     const tool = new GitSummaryTool('.');
-    const result = await tool.execute({ count: 2 }, new AbortController().signal);
+    const result = await tool.execute(
+      { count: 2 },
+      new AbortController().signal,
+    );
     expect(result.llmContent).toContain('abcdef1');
     expect(result.llmContent).toContain('test commit 1');
     expect(result.returnDisplay).toBe('2 commit(s)');
   });
 });
-

--- a/packages/core/src/tools/git-summary.test.ts
+++ b/packages/core/src/tools/git-summary.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { GitSummaryTool } from './git-summary.js';
-import { simpleGit } from 'simple-git';
+import { simpleGit, type SimpleGit } from 'simple-git';
 
 vi.mock('simple-git');
 
@@ -21,7 +21,7 @@ describe('GitSummaryTool', () => {
           { hash: 'abcdef2', message: 'test commit 2' },
         ],
       }),
-    } as any);
+    } as unknown as SimpleGit);
   });
 
   it('getDescription includes count', () => {

--- a/packages/core/src/tools/git-summary.ts
+++ b/packages/core/src/tools/git-summary.ts
@@ -53,15 +53,21 @@ export class GitSummaryTool extends BaseTool<GitSummaryParams, ToolResult> {
   ): Promise<ToolResult> {
     const error = this.validateToolParams(params);
     if (error) {
-      return { llmContent: `Error: ${error}`, returnDisplay: `Error: ${error}` };
+      return {
+        llmContent: `Error: ${error}`,
+        returnDisplay: `Error: ${error}`,
+      };
     }
     const count = params.count ?? 5;
     try {
       const git = simpleGit(this.repoPath);
       const log = await git.log({ n: count });
-      const lines = log.all.map(c => `- ${c.hash.slice(0,7)}: ${c.message}`);
+      const lines = log.all.map((c) => `- ${c.hash.slice(0, 7)}: ${c.message}`);
       const content = `Recent commits:\n${lines.join('\n')}`;
-      return { llmContent: content, returnDisplay: `${lines.length} commit(s)` };
+      return {
+        llmContent: content,
+        returnDisplay: `${lines.length} commit(s)`,
+      };
     } catch (e: unknown) {
       const msg = e instanceof Error ? e.message : String(e);
       return {
@@ -71,4 +77,3 @@ export class GitSummaryTool extends BaseTool<GitSummaryParams, ToolResult> {
     }
   }
 }
-

--- a/packages/core/src/tools/git-summary.ts
+++ b/packages/core/src/tools/git-summary.ts
@@ -1,0 +1,74 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import path from 'path';
+import { simpleGit } from 'simple-git';
+import { BaseTool, ToolResult } from './tools.js';
+
+export interface GitSummaryParams {
+  /** Number of commits to include in the summary */
+  count?: number;
+}
+
+export class GitSummaryTool extends BaseTool<GitSummaryParams, ToolResult> {
+  static readonly Name = 'git_summary';
+
+  constructor(private repoPath: string) {
+    super(
+      GitSummaryTool.Name,
+      'GitSummary',
+      'Returns the latest commit messages from the git repository.',
+      {
+        type: 'object',
+        properties: {
+          count: {
+            type: 'integer',
+            minimum: 1,
+            description: 'How many commits to include. Defaults to 5.',
+          },
+        },
+      },
+    );
+    this.repoPath = path.resolve(repoPath);
+  }
+
+  validateToolParams(params: GitSummaryParams): string | null {
+    if (params.count !== undefined && params.count <= 0) {
+      return 'count must be a positive integer';
+    }
+    return null;
+  }
+
+  getDescription(params: GitSummaryParams): string {
+    const count = params.count ?? 5;
+    return `summary of last ${count} commit(s)`;
+  }
+
+  async execute(
+    params: GitSummaryParams,
+    _signal: AbortSignal,
+  ): Promise<ToolResult> {
+    const error = this.validateToolParams(params);
+    if (error) {
+      return { llmContent: `Error: ${error}`, returnDisplay: `Error: ${error}` };
+    }
+    const count = params.count ?? 5;
+    try {
+      const git = simpleGit(this.repoPath);
+      const log = await git.log({ n: count });
+      const lines = log.all.map(c => `- ${c.hash.slice(0,7)}: ${c.message}`);
+      const content = `Recent commits:\n${lines.join('\n')}`;
+      return { llmContent: content, returnDisplay: `${lines.length} commit(s)` };
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return {
+        llmContent: `Error retrieving git summary: ${msg}`,
+        returnDisplay: `Error: ${msg}`,
+      };
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- introduce a new `GitSummaryTool` for showing recent commit messages
- register the tool within the core configuration
- document the tool in the tools API docs
- cover new tool with a unit test

## Testing
- `npm install`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_685f3a5408ec832c9798c254579aef4f