### PR TITLE
Add git_summary tool docs

### DIFF
--- a/docs/tools/git-summary.md
+++ b/docs/tools/git-summary.md
@@ -1,0 +1,31 @@
+# Git Summary Tool (`git_summary`)
+
+This document describes the `git_summary` tool for the Gemini CLI.
+
+## Description
+
+Use `git_summary` to display a concise list of recent Git commits from the current repository. This tool is helpful for quickly reviewing the latest changes without leaving the CLI.
+
+### Arguments
+
+`git_summary` takes one argument:
+
+- `count` (integer, optional): The number of commits to include. Defaults to `3` when not provided.
+
+## How to use `git_summary` with the Gemini CLI
+
+When called, `git_summary` runs `git log -n <count>` and returns the commit hashes and messages for the most recent commits.
+
+Usage:
+
+```
+git_summary(count=5)
+```
+
+### Example output
+
+```
+commit d4e5f6a Update documentation
+commit 1a2b3c4 Fix issue with login flow
+commit 789abcd Initial project setup
+```

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -49,6 +49,7 @@ Gemini CLI's built-in tools can be broadly categorized as follows:
 - **[Web Search Tool](./web-search.md) (`web_search`):** For searching the web.
 - **[Multi-File Read Tool](./multi-file.md) (`read_many_files`):** A specialized tool for reading content from multiple files or directories, often used by the `@` command.
 - **[Memory Tool](./memory.md) (`save_memory`):** For saving and recalling information across sessions.
+- **[Git Summary Tool](./git-summary.md) (`git_summary`):** Summarizes recent Git commit messages.
 
 Additionally, these tools incorporate:
 


### PR DESCRIPTION
## Summary
- document new git_summary tool
- link to git_summary docs from the tools index

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_685f47af24e8832ca2f57d80e174d1dc