### PR TITLE
Add share command

### DIFF
--- a/docs/cli/commands.md
+++ b/docs/cli/commands.md
@@ -9,6 +9,9 @@ Slash commands provide meta-level control over the CLI itself.
 - **`/bug`**
   - **Description:** File an issue about Gemini CLI. By default, the issue is filed within the GitHub repository for Gemini CLI. The string you enter after `/bug` will become the headline for the bug being filed. The default `/bug` behavior can be modified using the `bugCommand` setting in your `.gemini/settings.json` files.
 
+- **`/share`**
+  - **Description:** Export the current conversation to a Markdown file. Optionally specify a filename, e.g. `/share mychat.md`. If no name is provided, a timestamped file is created in the project root.
+
 - **`/chat`**
   - **Description:** Save and resume conversation history for branching conversation state interactively, or resuming a previous state from a later session.
   - **Sub-commands:**

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -683,6 +683,69 @@ export const useSlashCommandProcessor = (
         },
       },
       {
+        name: 'share',
+        description: 'export conversation to a Markdown file',
+        action: async (_mainCommand, _subCommand, args) => {
+          if (!config) {
+            addMessage({
+              type: MessageType.ERROR,
+              content: 'No configuration available.',
+              timestamp: new Date(),
+            });
+            return;
+          }
+          const geminiClient = await config.getGeminiClient();
+          const history = await geminiClient?.getHistory();
+          if (!history || history.length === 0) {
+            addMessage({
+              type: MessageType.INFO,
+              content: 'No conversation history to share.',
+              timestamp: new Date(),
+            });
+            return;
+          }
+
+          const fileName =
+            args && args.trim()
+              ? args.trim()
+              : `gemini-chat-${new Date().toISOString().replace(/[:.]/g, '-')}.md`;
+          const outputDir = config.getProjectRoot() || process.cwd();
+          const filePath = path.join(outputDir, fileName);
+
+          const markdown = history
+            .map((item) => {
+              const role = item.role === 'user' ? 'User' : 'Gemini';
+              const text = (item.parts || [])
+                .map((p) => {
+                  if (typeof p === 'string') return p;
+                  if ('text' in p && typeof p.text === 'string') return p.text;
+                  return '';
+                })
+                .join('');
+              return `**${role}:**\n${text}`;
+            })
+            .join('\n\n');
+
+          try {
+            await fs.mkdir(path.dirname(filePath), { recursive: true });
+            await fs.writeFile(filePath, markdown, 'utf-8');
+            addMessage({
+              type: MessageType.INFO,
+              content: `Conversation exported to ${filePath}`,
+              timestamp: new Date(),
+            });
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            addMessage({
+              type: MessageType.ERROR,
+              content: `Failed to write file: ${message}`,
+              timestamp: new Date(),
+            });
+          }
+        },
+      },
+      {
         name: 'chat',
         description:
           'Manage conversation history. Usage: /chat <list|save|resume> [tag]',


### PR DESCRIPTION
## Summary
- add `/share` command to export chat to a markdown file
- document the new `/share` command

## Testing
- `npm run preflight`

------
https://chatgpt.com/codex/tasks/task_b_685f6816c024832c8dbd5a2618a15bbe